### PR TITLE
fix: remove ueditor bower ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ueditor",
-  "version": "0.0.1",
+  "version": "1.1.1",
   "homepage": "https://github.com/zqjimlove/angular-ueditor",
   "authors": [
     "'Dio' <'zqjimlove@gmail.com'>"
@@ -19,7 +19,6 @@
     "test",
     "tests",
     "sample",
-    "ueditor",
     "src"
   ],
   "dependencies": {


### PR DESCRIPTION
回复bower install时忽略掉的ueditor目录